### PR TITLE
Remove type from script tag in server

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -36,7 +36,7 @@ function htmlTemplate({ reactDom, styleTags, css }) {
         
         <body>
             <div id="app">${reactDom}</div>
-            <script src="./app.bundle.js" type="text/babel"></script>
+            <script src="/app.bundle.js"></script>
         </body>
         </html>
     `;


### PR DESCRIPTION
- React Developer Tools were not working because of this