### PR TITLE
Replace use of deprecated/unsafe new Buffer constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ after_script:
 after_success:
   - yarn lh --perf=90 https://loving-golick-23af51.netlify.com
   - yarn bundlesize
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
Fixes #25 

- Install latest yarn version in before_install script
- Remove warning message in Travis CI

[More info](https://github.com/travis-ci/travis-ci/issues/7471)