### PR TITLE
Fix tests for auth components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
   - "10.0"
+before_script:
+  - yarn linter
 script:
   - yarn build
-after_script:
-  - yarn linter
   - yarn coveralls
 after_success:
   - yarn lh --perf=90 https://loving-golick-23af51.netlify.com

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -114,7 +114,8 @@ class SignIn extends React.Component<Props, State> {
   }
 }
 
+export const StyledSignIn = withTheme()(SignIn);
 export default connect(
   null,
   null
-)(withTheme()(SignIn));
+)(withTheme()(StyledSignIn));

--- a/src/components/SignIn/index.js
+++ b/src/components/SignIn/index.js
@@ -1,3 +1,4 @@
 import SignIn from "./SignIn";
 
+export { StyledSignIn } from "./SignIn";
 export default SignIn;

--- a/src/components/SignUp/SignUp.js
+++ b/src/components/SignUp/SignUp.js
@@ -113,7 +113,8 @@ class SignUp extends React.Component<Props, State> {
   }
 }
 
+export const StyledSignUp = withTheme()(SignUp);
 export default connect(
   null,
   null
-)(withTheme()(SignUp));
+)(withTheme()(StyledSignUp));

--- a/src/components/SignUp/index.js
+++ b/src/components/SignUp/index.js
@@ -1,3 +1,4 @@
 import SignUp from "./SignUp";
 
+export { StyledSignUp } from "./SignUp";
 export default SignUp;

--- a/src/components/__tests__/SignIn.test.js
+++ b/src/components/__tests__/SignIn.test.js
@@ -1,25 +1,10 @@
 import React from "react";
 import { render, waitForElement } from "react-testing-library";
-import { Router } from "react-router-dom";
-import { createMemoryHistory } from "history";
-import SignIn from "../SignIn";
-
-const renderWithRouter = (
-  ui,
-  {
-    route = "/",
-    history = createMemoryHistory({ initialEntries: [route] }),
-  } = {}
-) => ({
-  ...render(<Router history={history}>{ui}</Router>),
-  history,
-});
-
-const renderComponent = () => renderWithRouter(<SignIn />);
+import { StyledSignIn } from "../SignIn";
 
 describe("Test SignIn", () => {
   test("it renders sign in text", async () => {
-    const { getByText } = renderComponent();
+    const { getByText } = render(<StyledSignIn />);
     await waitForElement(() => getByText(/Sign in/i));
   });
 });

--- a/src/components/__tests__/SignUp.test.js
+++ b/src/components/__tests__/SignUp.test.js
@@ -1,25 +1,10 @@
 import React from "react";
 import { render, waitForElement } from "react-testing-library";
-import { Router } from "react-router-dom";
-import { createMemoryHistory } from "history";
-import SignUp from "../SignUp";
-
-const renderWithRouter = (
-  ui,
-  {
-    route = "/",
-    history = createMemoryHistory({ initialEntries: [route] }),
-  } = {}
-) => ({
-  ...render(<Router history={history}>{ui}</Router>),
-  history,
-});
-
-const renderComponent = () => renderWithRouter(<SignUp />);
+import { StyledSignUp } from "../SignUp/SignUp";
 
 describe("Test SignUp", () => {
-  test("it renders Sign up text", async () => {
-    const { getByText } = renderComponent();
+  test("it renders sign up text", async () => {
+    const { getByText } = render(<StyledSignUp />);
     await waitForElement(() => getByText(/Sign up/i));
   });
 });


### PR DESCRIPTION
Problem and solution explained in this [material-ui issue](https://github.com/mui-org/material-ui/issues/11864#issuecomment-463980288)

Travis CI config has also changed in order to launch the linter in the `before_script` life cycle and the test in the `script` life cycle.